### PR TITLE
bump to correct Lucene Phonetic 3.6 artifact ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-phonetic</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Phonetic Analysis for ElasticSearch</description>
     <inceptionYear>2009</inceptionYear>
@@ -47,7 +47,7 @@
 
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-phonetic</artifactId>
+            <artifactId>lucene-phonetic</artifactId>
             <version>3.6.0</version>
             <scope>compile</scope>
         </dependency>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -19,7 +19,7 @@
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
-               <include>org.apache.lucene:lucene-analyzers-phonetic</include>
+               <include>org.apache.lucene:lucene-phonetic</include>
                <include>commons-codec:commons-codec</include>
             </includes>
         </dependencySet>


### PR DESCRIPTION
Just a small fix. I made a mistake in my first pull request, the Lucene Phonetic 3.6 artifact ID was wrong. It was the one I selected in my Lucene Maven build. The official Lucene Ant build uses a different one.
